### PR TITLE
workshop ref link fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This hands-on workshop is where you will learn about a number of AWS services th
 
 ## Start the workshop:
 
-Visit the site to get started: [https://idm-infrastructure.awssecworkshops.com/](https://infrastructure.awssecworkshops.com/)
+Visit the site to get started: [https://idm-infrastructure.awssecworkshops.com/](https://idm-infrastructure.awssecworkshops.com/)
 
 ## License Summary
 


### PR DESCRIPTION
The link in the readme pointed to a non-existent page. Changed it to the right one.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
